### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Toronto Community Network
+
+TBA
+
+## Project Management
+We use [Teams](https://github.com/orgs/tomeshnet/teams/toronto-community-network/teams) to manage membership of working groups and [Projects](https://github.com/tomeshnet/mesh-deployment/projects/1) to track task status on a public project board.
+These are our current [working groups](https://github.com/orgs/tomeshnet/teams/toronto-community-network/teams).
+
+### Communications and Community Engagement [:busts_in_silhouette:](https://github.com/orgs/tomeshnet/teams/communications-and-community-engagement)
+Connect with people living and working in the areas served by the network(s), inform people regarding intentions and activities of the community network and engage them in dialogue with a view to mutual learning and collaboration in advancing the value of the network and related opportunities in the community.
+
+| Spaces     |   |
+|:-----------|:--|
+| Meetings   | TBA |
+| Chat       | [#deployment:tomesh.net](https://chat.tomesh.net/#/room/#deployment:tomesh.net) |
+| Tasks      | [`Communications`](https://github.com/tomeshnet/mesh-deployment/projects/1?card_filter_query=label%3ACommunications) label |
+
+### Network Planning, Design and Operations [:busts_in_silhouette:](https://github.com/orgs/tomeshnet/teams/network-planning-design-and-operations)
+Plan, design, implement and maintain a well-functioning community network.
+
+| Spaces     |   |
+|:-----------|:--|
+| Meetings   | TBA |
+| Chat       | [#deployment:tomesh.net](https://chat.tomesh.net/#/room/#deployment:tomesh.net) |
+| Tasks      | [`Network`](https://github.com/tomeshnet/mesh-deployment/projects/1?card_filter_query=label%3ANetwork) label |
+
+### Organizational and Program Governance [:busts_in_silhouette:](https://github.com/orgs/tomeshnet/teams/organizational-and-program-governance)
+Develop administrative processes ensuring Toronto Mesh meets their commitments.
+Attend to assets and resources.
+Assist in integrating and synthesizing priorities, plans and schedules across different disciplines and activities of the community network.
+Formalize relationships and agreements with and within the community network.
+
+| Spaces     |   |
+|:-----------|:--|
+| Meetings   | TBA |
+| Chat       | [#deployment:tomesh.net](https://chat.tomesh.net/#/room/#deployment:tomesh.net) |
+| Tasks      | [`Governance`](https://github.com/tomeshnet/mesh-deployment/projects/1?card_filter_query=label%3AGovernance) label |
+
+### Project Operations [:busts_in_silhouette:](https://github.com/orgs/tomeshnet/teams/project-operations)
+Assist in organizing and removing barriers to the completion of work - including projects involving production of a funding application, design and deployment of network equipment, convening of meetings and workshops, etc.
+
+| Spaces     |   |
+|:-----------|:--|
+| Meetings   | TBA |
+| Chat       | [#deployment:tomesh.net](https://chat.tomesh.net/#/room/#deployment:tomesh.net) |
+| Tasks      | [`Operations`](https://github.com/tomeshnet/mesh-deployment/projects/1?card_filter_query=label%3AOperations) label |
+
+---
+
+If you would like to contribute to the _Toronto Community Network_ project, please email [hello@tomesh.net](mailto:hello@tomesh.net) to introduce yourself and indicate in which areas you may like to participate.
+In order to do our best work together we have a [Code of Conduct](https://tomesh.net/code-of-conduct/).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 TBA
 
 ## Project Management
-We use [Teams](https://github.com/orgs/tomeshnet/teams/toronto-community-network/teams) to manage membership of working groups and [Projects](https://github.com/tomeshnet/mesh-deployment/projects/1) to track task status on a public project board.
+We use [Teams](https://github.com/orgs/tomeshnet/teams/toronto-community-network/teams) to manage membership of working groups and [Projects](https://github.com/tomeshnet/toronto-community-network/projects/1) to track task status on a public project board.
 These are our current [working groups](https://github.com/orgs/tomeshnet/teams/toronto-community-network/teams).
 
 ### Communications and Community Engagement [:busts_in_silhouette:](https://github.com/orgs/tomeshnet/teams/communications-and-community-engagement)
@@ -13,7 +13,7 @@ Connect with people living and working in the areas served by the network(s), in
 |:-----------|:--|
 | Meetings   | TBA |
 | Chat       | [#deployment:tomesh.net](https://chat.tomesh.net/#/room/#deployment:tomesh.net) |
-| Tasks      | [`Communications`](https://github.com/tomeshnet/mesh-deployment/projects/1?card_filter_query=label%3ACommunications) label |
+| Tasks      | [`communications`](https://github.com/tomeshnet/toronto-community-network/projects/1?card_filter_query=label%3Acommunications) label |
 
 ### Network Planning, Design and Operations [:busts_in_silhouette:](https://github.com/orgs/tomeshnet/teams/network-planning-design-and-operations)
 Plan, design, implement and maintain a well-functioning community network.
@@ -22,7 +22,7 @@ Plan, design, implement and maintain a well-functioning community network.
 |:-----------|:--|
 | Meetings   | TBA |
 | Chat       | [#deployment:tomesh.net](https://chat.tomesh.net/#/room/#deployment:tomesh.net) |
-| Tasks      | [`Network`](https://github.com/tomeshnet/mesh-deployment/projects/1?card_filter_query=label%3ANetwork) label |
+| Tasks      | [`network`](https://github.com/tomeshnet/toronto-community-network/projects/1?card_filter_query=label%3Anetwork) label |
 
 ### Organizational and Program Governance [:busts_in_silhouette:](https://github.com/orgs/tomeshnet/teams/organizational-and-program-governance)
 Develop administrative processes ensuring Toronto Mesh meets their commitments.
@@ -34,7 +34,7 @@ Formalize relationships and agreements with and within the community network.
 |:-----------|:--|
 | Meetings   | TBA |
 | Chat       | [#deployment:tomesh.net](https://chat.tomesh.net/#/room/#deployment:tomesh.net) |
-| Tasks      | [`Governance`](https://github.com/tomeshnet/mesh-deployment/projects/1?card_filter_query=label%3AGovernance) label |
+| Tasks      | [`governance`](https://github.com/tomeshnet/toronto-community-network/projects/1?card_filter_query=label%3Agovernance) label |
 
 ### Project Operations [:busts_in_silhouette:](https://github.com/orgs/tomeshnet/teams/project-operations)
 Assist in organizing and removing barriers to the completion of work - including projects involving production of a funding application, design and deployment of network equipment, convening of meetings and workshops, etc.
@@ -43,7 +43,7 @@ Assist in organizing and removing barriers to the completion of work - including
 |:-----------|:--|
 | Meetings   | TBA |
 | Chat       | [#deployment:tomesh.net](https://chat.tomesh.net/#/room/#deployment:tomesh.net) |
-| Tasks      | [`Operations`](https://github.com/tomeshnet/mesh-deployment/projects/1?card_filter_query=label%3AOperations) label |
+| Tasks      | [`operations`](https://github.com/tomeshnet/toronto-community-network/projects/1?card_filter_query=label%3Aoperations) label |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,20 +9,23 @@ These are our current [working groups](https://github.com/orgs/tomeshnet/teams/t
 ### Communications and Community Engagement [:busts_in_silhouette:](https://github.com/orgs/tomeshnet/teams/communications-and-community-engagement)
 Connect with people living and working in the areas served by the network(s), inform people regarding intentions and activities of the community network and engage them in dialogue with a view to mutual learning and collaboration in advancing the value of the network and related opportunities in the community.
 
-| Spaces     |   |
-|:-----------|:--|
-| Meetings   | TBA |
-| Chat       | [#deployment:tomesh.net](https://chat.tomesh.net/#/room/#deployment:tomesh.net) |
-| Tasks      | [`communications`](https://github.com/tomeshnet/toronto-community-network/projects/1?card_filter_query=label%3Acommunications) label |
+| Spaces      |   |
+|:------------|:--|
+| Meetings    | TBA |
+| Group Email | communications@tomesh.net |
+| Chat        | [#deployment:tomesh.net](https://chat.tomesh.net/#/room/#deployment:tomesh.net) |
+| Tasks       | [`communications`](https://github.com/tomeshnet/toronto-community-network/projects/1?card_filter_query=label%3Acommunications) label |
+
 
 ### Network Planning, Design and Operations [:busts_in_silhouette:](https://github.com/orgs/tomeshnet/teams/network-planning-design-and-operations)
 Plan, design, implement and maintain a well-functioning community network.
 
-| Spaces     |   |
-|:-----------|:--|
-| Meetings   | TBA |
-| Chat       | [#deployment:tomesh.net](https://chat.tomesh.net/#/room/#deployment:tomesh.net) |
-| Tasks      | [`network`](https://github.com/tomeshnet/toronto-community-network/projects/1?card_filter_query=label%3Anetwork) label |
+| Spaces      |   |
+|:------------|:--|
+| Meetings    | TBA |
+| Group Email | network@tomesh.net |
+| Chat        | [#deployment:tomesh.net](https://chat.tomesh.net/#/room/#deployment:tomesh.net) |
+| Tasks       | [`network`](https://github.com/tomeshnet/toronto-community-network/projects/1?card_filter_query=label%3Anetwork) label |
 
 ### Organizational and Program Governance [:busts_in_silhouette:](https://github.com/orgs/tomeshnet/teams/organizational-and-program-governance)
 Develop administrative processes ensuring Toronto Mesh meets their commitments.
@@ -30,22 +33,27 @@ Attend to assets and resources.
 Assist in integrating and synthesizing priorities, plans and schedules across different disciplines and activities of the community network.
 Formalize relationships and agreements with and within the community network.
 
-| Spaces     |   |
-|:-----------|:--|
-| Meetings   | TBA |
-| Chat       | [#deployment:tomesh.net](https://chat.tomesh.net/#/room/#deployment:tomesh.net) |
-| Tasks      | [`governance`](https://github.com/tomeshnet/toronto-community-network/projects/1?card_filter_query=label%3Agovernance) label |
+| Spaces      |   |
+|:------------|:--|
+| Meetings    | TBA |
+| Group Email | governance@tomesh.net |
+| Chat        | [#deployment:tomesh.net](https://chat.tomesh.net/#/room/#deployment:tomesh.net) |
+| Tasks       | [`governance`](https://github.com/tomeshnet/toronto-community-network/projects/1?card_filter_query=label%3Agovernance) label |
 
 ### Project Operations [:busts_in_silhouette:](https://github.com/orgs/tomeshnet/teams/project-operations)
 Assist in organizing and removing barriers to the completion of work - including projects involving production of a funding application, design and deployment of network equipment, convening of meetings and workshops, etc.
 
-| Spaces     |   |
-|:-----------|:--|
-| Meetings   | TBA |
-| Chat       | [#deployment:tomesh.net](https://chat.tomesh.net/#/room/#deployment:tomesh.net) |
-| Tasks      | [`operations`](https://github.com/tomeshnet/toronto-community-network/projects/1?card_filter_query=label%3Aoperations) label |
+| Spaces      |   |
+|:------------|:--|
+| Meetings    | TBA |
+| Group Email | operations@tomesh.net |
+| Chat        | [#deployment:tomesh.net](https://chat.tomesh.net/#/room/#deployment:tomesh.net) |
+| Tasks       | [`operations`](https://github.com/tomeshnet/toronto-community-network/projects/1?card_filter_query=label%3Aoperations) label |
 
----
+## Get Involved
 
-If you would like to contribute to the _Toronto Community Network_ project, please email [hello@tomesh.net](mailto:hello@tomesh.net) to introduce yourself and indicate in which areas you may like to participate.
+If you would like to contribute to the _Toronto Community Network_ project, please email [hello@tomesh.net](mailto:hello@tomesh.net) to introduce yourself and indicate how you may like to participate.
+
+If you have general interest in our project and would like to stay connected, you can join the [Toronto Mesh mailing list](https://lists.hypha.coop/cgi-bin/mailman/listinfo/tomeshnet).
+
 In order to do our best work together we have a [Code of Conduct](https://tomesh.net/code-of-conduct/).


### PR DESCRIPTION
The working groups are set up as teams.

The text is copied from @TimTor's slides and just fixing that WG title mix up.

The 4 teams have exact same name and description of the slides, but the labels can't be so long so they are shortened (github doesn't allow).

@darkdrgn2k and others would need to attach one (or more) of the labels to each issue to get things to look right. I renamed the `Outreach` tag to `Communications` to match the group.

I hope we can also agree on #30 and rename the repo and update links here before announcing anything.