### PR TITLE
added wireless information

### DIFF
--- a/network/scripts/unms_exporter/unms_exporter.py
+++ b/network/scripts/unms_exporter/unms_exporter.py
@@ -96,19 +96,19 @@ def write_prometheus_data(target_id, devices, ifaces, airmax, writer):
             continue
 
         write('node_uname_info{nodename="' + dev['identification']['name'] + '", sysname="' +  dev['identification']['model'] + '", release="' +  dev['identification']['firmwareVersion'] + '"} 1')
-        write("ram " + str(dev['overview']['ram']))
-        write("cpu " + str(dev['overview']['cpu']))
-        write("uptime " + str(dev['overview']['uptime']))
+        write("node_cpu_ram " + str(dev['overview']['ram']))
+        write("node_cpu_usage " + str(dev['overview']['cpu']))
+        write("node_boot_time_seconds " + str(dev['overview']['uptime']))
 
         if dev['overview'].get('frequency') is not None:
-            write("frequency " + str(dev['overview']['frequency']))
+            write("wireless_frequency " + str(dev['overview']['frequency']))
 
         if dev['overview'].get("signal") is not None:
-            write("signal " + str(dev['overview']["signal"]))
+            write("wireless_signal " + str(dev['overview']["signal"]))
 
         if dev['overview'].get("downlinkCapacity") is not None:
-            write("downlinkCapacity " + str(dev['overview']['downlinkCapacity']))
-            write("uplinkCapacity " + str(dev['overview']['uplinkCapacity']))
+            write("ubnt_downlinkCapacity " + str(dev['overview']['downlinkCapacity']))
+            write("ubnt_uplinkCapacity " + str(dev['overview']['uplinkCapacity']))
 
         if dev['overview'].get("linkScore") is not None:
             write("ubnt_theoreticalUplinkCapacity " + str(dev['overview']['theoreticalUplinkCapacity']))
@@ -138,7 +138,7 @@ def write_prometheus_data(target_id, devices, ifaces, airmax, writer):
                         write("ubnt_station_txBytes{name=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["txBytes"]))
                         write("ubnt_station_rxSignal{name=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["rxSignal"]))
                         write("ubnt_station_txSignal{name=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["txSignal"]))
-                        
+
         for iface in ifaces:
             name = iface['identification']['name']
 
@@ -153,7 +153,7 @@ def write_prometheus_data(target_id, devices, ifaces, airmax, writer):
             write('node_network_transmit_rate{device="' + name + '"} ' + str(iface["statistics"]["txrate"]))
             write('node_network_mtu_bytes{device="' + name + '"} ' + str(iface["mtu"]))
             write('node_network_dropped_total{device="' + name + '"} ' + str(iface["statistics"]["dropped"]))  # Not sure whether receive or transmit, or both
-        
+
         # The target has been found and all data has been written
         break
 
@@ -214,3 +214,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+    

--- a/network/scripts/unms_exporter/unms_exporter.py
+++ b/network/scripts/unms_exporter/unms_exporter.py
@@ -135,10 +135,10 @@ def write_prometheus_data(target_id, devices, ifaces, airmax, writer):
                     for stn in int["stations"]:
                         write("wireless_link_uptime{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["uptime"]))
                         write("wireless_link_latency{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["latency"]))
-                        write("wireless_link_rxBytes{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["rxBytes"]))
-                        write("wireless_link_txBytes{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["txBytes"]))
-                        write("wirlesss_link_rxSignal{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["rxSignal"]))
-                        write("wireless_link_txSignal{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["txSignal"]))
+                        write("wireless_link_receive_bytes_total{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["rxBytes"]))
+                        write("wireless_link_transmit_bytes_total{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["txBytes"]))
+                        write("wirlesss_link_receive_signal{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["rxSignal"]))
+                        write("wireless_link_transmit_signal{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["txSignal"]))
 
         for iface in ifaces:
             name = iface['identification']['name']

--- a/network/scripts/unms_exporter/unms_exporter.py
+++ b/network/scripts/unms_exporter/unms_exporter.py
@@ -134,12 +134,12 @@ def write_prometheus_data(target_id, devices, ifaces, airmax, writer):
                 ifmac = iface['identification']['mac']
                 if iface.get("stations") is not None:
                     for stn in iface["stations"]:
-                        write("wireless_link_uptime{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["uptime"]))
-                        write("wireless_link_latency{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["latency"]))
-                        write("wireless_link_receive_bytes_total{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["rxBytes"]))
-                        write("wireless_link_transmit_bytes_total{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["txBytes"]))
-                        write("wirlesss_link_receive_signal{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["rxSignal"]))
-                        write("wireless_link_transmit_signal{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["txSignal"]))
+                        write('wireless_link_uptime{type="' + mode + '" device="' + ifname + '" sourcemac="' + ifmac + '" targetmac="' + stn["mac"] + '"} ' + str(stn["uptime"]))
+                        write('wireless_link_latency{type="' + mode + '" device="' + ifname + '" sourcemac="' + ifmac + '" targetmac="' + stn["mac"] + '"} ' + str(stn["latency"]))
+                        write('wireless_link_receive_bytes_total{type="' + mode + '" device="' + ifname + '" sourcemac="' + ifmac + '" targetmac="' + stn["mac"] + '"} ' + str(stn["rxBytes"]))
+                        write('wireless_link_transmit_bytes_total{type="' + mode + '" device="' + ifname + '" sourcemac="' + ifmac + '" targetmac="' + stn["mac"] + '"} ' + str(stn["txBytes"]))
+                        write('wirlesss_link_receive_signal{type="' + mode + '" device="' + ifname + '" sourcemac="' + ifmac + '" targetmac="' + stn["mac"] + '"} ' + str(stn["rxSignal"]))
+                        write('wireless_link_transmit_signal{type="' + mode + '" device="' + ifname + '" sourcemac="' + ifmac + '" targetmac="' + stn["mac"] + '"} ' + str(stn["txSignal"]))
 
         for iface in ifaces:
             name = iface['identification']['name']

--- a/network/scripts/unms_exporter/unms_exporter.py
+++ b/network/scripts/unms_exporter/unms_exporter.py
@@ -122,6 +122,7 @@ def write_prometheus_data(target_id, devices, ifaces, airmax, writer):
             write("ubnt_stationsCount " + str(dev['overview']['stationsCount']))
 
         if airmax.get("airmax") is not None:
+            mode=airmax['airmax']['wirelessMode']
             write("ubnt_noiseFloor " + str(airmax['airmax']['noiseFloor']))
             write("ubnt_wlanRxBytes " + str(airmax['airmax']['wlanRxBytes']))
             write("ubnt_wlanTxBytes " + str(airmax['airmax']['wlanTxBytes']))
@@ -132,12 +133,12 @@ def write_prometheus_data(target_id, devices, ifaces, airmax, writer):
                 if int.get("stations") is not None:
 
                     for stn in int["stations"]:
-                        write("ubnt_station_uptime{name\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["uptime"]))
-                        write("ubnt_station_latency{name=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["latency"]))
-                        write("ubnt_station_rxBytes{name=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["rxBytes"]))
-                        write("ubnt_station_txBytes{name=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["txBytes"]))
-                        write("ubnt_station_rxSignal{name=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["rxSignal"]))
-                        write("ubnt_station_txSignal{name=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["txSignal"]))
+                        write("wireless_link_uptime{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["uptime"]))
+                        write("wireless_link_latency{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["latency"]))
+                        write("wireless_link_rxBytes{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["rxBytes"]))
+                        write("wireless_link_txBytes{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["txBytes"]))
+                        write("wirlesss_link_rxSignal{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["rxSignal"]))
+                        write("wireless_link_txSignal{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["txSignal"]))
 
         for iface in ifaces:
             name = iface['identification']['name']
@@ -214,4 +215,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-    

--- a/network/scripts/unms_exporter/unms_exporter.py
+++ b/network/scripts/unms_exporter/unms_exporter.py
@@ -30,7 +30,7 @@ else:
     UNMS_HOST = "unms.tomesh.net"
 
 
-VERSION = "0.2.1"
+VERSION = "0.3.0"
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -67,6 +67,7 @@ def find_device_id_by_name(name, devices):
             return dev["identification"]["id"]
     return ""
 
+
 def find_device_id_by_ip(ip, devices):
     for dev in devices:
         if dev["ipAddress"].split('/')[0] == ip:
@@ -79,7 +80,8 @@ def write_prometheus_data(target_id, devices, ifaces, airmax, writer):
     Writes a string of prometheus data, using the passed JSON.
 
     devices: devices JSON, in Python format
-    ifaces: Interfaces JSON for the target (using the target's device id), in Python format.
+    ifaces:  Interfaces JSON for the target (using the target's device ID), in Python format.
+    airmax:  airmax JSON, using the target's device ID, in Python format.
 
     writer:
         Where data is written to. Any class with a write() method will work.
@@ -122,17 +124,16 @@ def write_prometheus_data(target_id, devices, ifaces, airmax, writer):
             write("ubnt_stationsCount " + str(dev['overview']['stationsCount']))
 
         if airmax.get("airmax") is not None:
-            mode=airmax['airmax']['wirelessMode']
+            mode = airmax['airmax']['wirelessMode']
             write("ubnt_noiseFloor " + str(airmax['airmax']['noiseFloor']))
             write("ubnt_wlanRxBytes " + str(airmax['airmax']['wlanRxBytes']))
             write("ubnt_wlanTxBytes " + str(airmax['airmax']['wlanTxBytes']))
 
-            for int in airmax['interfaces']:
-                ifname=int['identification']['name']
-                ifmac=int['identification']['mac']
-                if int.get("stations") is not None:
-
-                    for stn in int["stations"]:
+            for iface in airmax['interfaces']:
+                ifname = iface['identification']['name']
+                ifmac = iface['identification']['mac']
+                if iface.get("stations") is not None:
+                    for stn in iface["stations"]:
                         write("wireless_link_uptime{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["uptime"]))
                         write("wireless_link_latency{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["latency"]))
                         write("wireless_link_receive_bytes_total{type=\"" + mode + "\" device=\"" + ifname + "\" sourcemac=\"" + ifmac + "\" targetmac=\"" + stn["mac"] + "\"} " + str(stn["rxBytes"]))


### PR DESCRIPTION
created

for now
`node_cpu_usage` for cpu (seems close enough)
`node_ram_usage` for ram

I'll check the windows version of node exporter, it doesnt have load so it may be a clue there

`frequency` and `signal` added `wireless_`
`node_boot_time_seconds` is the new name for `node_boot_time` according to node exporter

added `ubnt_` to ubiquti specific items
added more wireless info and STATION (connected device) information